### PR TITLE
 Initial API Support for Users for Now Playing 

### DIFF
--- a/pages/api/spotify/now-playing.js
+++ b/pages/api/spotify/now-playing.js
@@ -7,20 +7,42 @@ var SpotifyWebApi = require('spotify-web-api-node');
 
 export default async function handler(req, res) {
     const session = await unstable_getServerSession(req, res, authOptions)
+    const api_key = req.query.key
+    const email = req.query.email
 
-    if (!session) {
-        res.status(401).send({
-            'message': 'Not authorized.'
-        })
+    if (!session || !api_key || !email) {
+        if (api_key && email) {
+            console.log('Granting access, has API key')
+        } else {
+            return res.status(401).send({
+                'message': 'Not authorized because no authentication.'
+            })
+        }
     }
 
+    var access_token = null
+
+    if (session){
+        access_token = session.tokens.access_token
+    } else {
+        // Two options for this:
+        // 1 - query NextJS Auth's database for the email, then the primary key to get access_token
+        // 2 - Store access_token in my other user table which also has categories.
+        access_token = null
+    }
+
+    if (!access_token) {
+        return res.status(400).send({
+            message: 'Error getting now playing.'
+        })
+    }
     var spotifyApi = new SpotifyWebApi({
-        accessToken: session.tokens.access_token
+        accessToken: access_token
     })
 
     spotifyApi.getMyCurrentPlayingTrack({
     }).then(function (data) {
-        return res.send({'items': data.body.item})
+        return res.send({ 'items': data.body.item })
     }, function (err) {
         console.log('Something went wrong!', err);
     });


### PR DESCRIPTION
I still need to determine how I want to get the access_token for the users:

1. Store the access token in two places (NextJS Auth table AND my user table)
2. Create another index for the NextJS table

I'm thinking the 2nd option so you don't have to keep track of multiple keys. And it'll allow us to automate the future Event Bridge to track the all user's now playing.