### PR TITLE
Authentication Testing for Central Auth

### DIFF
--- a/pages/api/spotify/authenticate-testing.js
+++ b/pages/api/spotify/authenticate-testing.js
@@ -1,0 +1,34 @@
+import { unstable_getServerSession } from "next-auth"
+import { authOptions } from '../auth/[...nextauth]'
+
+var SpotifyWebApi = require('spotify-web-api-node');
+
+/*
+    I'm not sure if this separate function "saves" me the effort with handling authentication. I'll still have check the session or email/API key.
+    The SpotifyWebAPI still needs an access token; I'm not sure how to Constructors work, yet.
+    Therefore, I think centralizing the spotify calls in one big file with multiple functions is the solution.
+*/
+
+export default async function handler(req, res) {
+    const session = await unstable_getServerSession(req, res, authOptions)
+    const api_key = req.query.key
+    const email = req.query.email
+    var authenticate = null
+
+    if (api_key && email) {
+        const query_authenticate = await fetch('http://localhost:3000/api/spotify/authenticate?key=' + api_key + "&email=" + email)
+        authenticate = await query_authenticate
+    } else {
+        const query_authenticate = await fetch('http://localhost:3000/api/spotify/authenticate', { method: 'POST', body: JSON.stringify(session) })
+        authenticate = await query_authenticate
+    }
+
+    if (authenticate.status == 401) {
+        return res.status(401).send({
+            message: 'Unauthorized'
+        })
+    }
+    return res.status(200).send({
+        message: 'Hello'
+    })
+}

--- a/pages/api/spotify/authenticate.js
+++ b/pages/api/spotify/authenticate.js
@@ -1,0 +1,53 @@
+import { unstable_getServerSession } from "next-auth"
+import { authOptions } from '../auth/[...nextauth]'
+
+var SpotifyWebApi = require('spotify-web-api-node');
+
+// https://developer.spotify.com/documentation/web-api/reference/#/operations/get-the-users-currently-playing-track
+
+export default async function handler(req, res) {
+    const session = await unstable_getServerSession(req, res, authOptions)
+    const api_key = req.query.key
+    const email = req.query.email
+
+    if (!session || !api_key || !email) {
+        if (api_key && email) {
+            console.log('Granting access, has API key')
+        } else if (session){
+            console.log('Has session, granting access')
+        }
+        else {
+            return res.status(401).send({
+                'message': 'Not authorized because no authentication.'
+            })
+        }
+    }
+
+    var access_token = null
+
+    if (session){
+        access_token = session.tokens.access_token
+    } else {
+        access_token = null
+    }
+
+    if (!access_token) {
+        return res.status(400).send({
+            message: 'Error getting now playing.'
+        })
+    }
+    var spotifyApi = new SpotifyWebApi({
+        accessToken: access_token
+    })
+
+    if (!spotifyApi) {
+        res.status(401).send({
+            message: 'Not able to authenticate.'
+        })
+    }
+
+    res.status(200).send({
+        access_token: access_token,
+        spotifyApi: spotifyApi
+    })
+}

--- a/pages/api/spotify/authenticate.js
+++ b/pages/api/spotify/authenticate.js
@@ -6,9 +6,16 @@ var SpotifyWebApi = require('spotify-web-api-node');
 // https://developer.spotify.com/documentation/web-api/reference/#/operations/get-the-users-currently-playing-track
 
 export default async function handler(req, res) {
-    const session = await unstable_getServerSession(req, res, authOptions)
     const api_key = req.query.key
     const email = req.query.email
+
+    var session = null
+
+    if (req.method == 'POST') {
+        session = JSON.parse(req.body)
+    } else {
+        session = await unstable_getServerSession(req, res, authOptions)
+    }
 
     if (!session || !api_key || !email) {
         if (api_key && email) {


### PR DESCRIPTION
I'm not sure if this separate function "saves" me the effort with handling authentication. I'll still have check the session or email/API key.

The SpotifyWebAPI still needs an access token; I'm not sure how to Constructors work, yet.

Therefore, I think centralizing the spotify calls in one big file with multiple functions is the solution.